### PR TITLE
Add missing Cartfile

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,1 @@
+github "tid-kijyun/Kanna"


### PR DESCRIPTION
Adding the `Cartfile` will allow carthage to download all `RSS` dependencies.
